### PR TITLE
Add new post signifier to avoid user frustration

### DIFF
--- a/hugo/layouts/_default/single.html
+++ b/hugo/layouts/_default/single.html
@@ -54,6 +54,8 @@
           {{ if eq .Prev.Type "posts" }}
             <a class="basic-alignment right" href="{{ .Prev.Permalink }}" title="Previous Post: {{ .Prev.Title }}">{{ .Prev.Title }} &raquo;</a>
           {{ end }}
+        {{ else }}
+          <b class="basic-alignment right">Сбор тем начинается со Среды</b>
         {{ end }}
       </p>
       <div class="sharing">


### PR DESCRIPTION
term signifiers explained by author (Don Norman) - https://www.youtube.com/watch?v=UtulTXJLGOI

![preview](https://i.imgur.com/g9SfODX.png)
negative space and prev link asymmetry creates a perfect focal point for new post message